### PR TITLE
Update major version options

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -5,7 +5,7 @@
 # User did not enter a major version selection, prompt for one
 if [ "$1" = "" ]; then
   echo "Which kernel version do you want to build?"
-  select major_version in "4.19" "5.0"; do
+  select major_version in "4.19" "5.1"; do
     break;
   done
 else


### PR DESCRIPTION
Since 5.0 is no longer in the repository, the major_version options should be 4.19 and 5.1.